### PR TITLE
Automate the build process with nodejs

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,33 @@
+const makensis = require('makensis');
+const axios = require('axios');
+const path = require('path');
+
+async function doBuild() {
+  try {
+    const response = await axios.get('https://api.github.com/repos/cmderdev/cmder/releases/latest');
+    await buildRelease(response.data.tag_name);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function buildRelease(tag) {
+  let options = {
+    verbose: 2,
+    define: {
+        'CMDER_VERSION': tag
+    }
+  };
+
+  console.log('Found latest tag:', tag);
+  console.log('Building NSIS installer for Cmder', options.define.CMDER_VERSION);
+
+  try {
+    let output = await makensis.compile(path.join(__dirname, 'cmder_inst.nsi'), options);
+    console.log(`Standard output:\n${output.stdout}`);
+  } catch (output) {
+    console.error(`Exit Code ${output.status}: ${output.stderr}`);
+  }
+}
+
+doBuild();

--- a/cmder_inst.nsi
+++ b/cmder_inst.nsi
@@ -44,9 +44,8 @@
 ; General
 
     !define INSTALLER_VERSION "0.0.1-alpha"
-    !define CMDER_VERSION "1.3.0"
     !define APP_NAME "Cmder"
-    !define CMDER_DLURL "http://github.com/cmderdev/cmder/releases/download/v${CMDER_VERSION}/cmder_mini.zip"
+    !define CMDER_DLURL "http://github.com/cmderdev/cmder/releases/download/${CMDER_VERSION}/cmder_mini.zip"
     !define CMDER_URL "http://cmder.net"
 
     !define APP_INSTALLER_TEXT "${APP_NAME} Installer Ver. ${INSTALLER_VERSION}"
@@ -54,7 +53,7 @@
 
     ; Name / File
     Name "${APP_NAME} v${CMDER_VERSION}"
-    OutFile "cmder_inst_${INSTALLER_VERSION}.exe"
+    OutFile "cmder_inst_${CMDER_VERSION}.exe"
         
     ; Default Installation Folder
     InstallDir $PROGRAMFILES\${APP_NAME}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "cmder_inst",
+    "version": "1.0.0",
+    "license": "MIT",
+    "scripts": {
+        "build": "node build.js"
+    },
+    "dependencies": {
+        "axios": "^0.18.0",
+        "makensis": "^0.12.6"
+    }
+}


### PR DESCRIPTION
This allows the use of nodejs to build the installer. It automatically defines the current version from the tag name using github api to get the tag name.

